### PR TITLE
Fix CLI option conflicts

### DIFF
--- a/infrastructure/esc/inject_secrets.sh
+++ b/infrastructure/esc/inject_secrets.sh
@@ -35,7 +35,7 @@ while [[ $# -gt 0 ]]; do
       shift
       shift
       ;;
-    --output|-o)
+    --output|-f)
       OUTPUT_FILE="$2"
       shift
       shift

--- a/infrastructure/esc/setup_esc.sh
+++ b/infrastructure/esc/setup_esc.sh
@@ -39,7 +39,7 @@ while [[ $# -gt 0 ]]; do
       shift
       shift
       ;;
-    --output|-o)
+    --output|-f)
       OUTPUT_FILE="$2"
       shift
       shift


### PR DESCRIPTION
## Summary
- fix conflicting short options for `setup_esc.sh`
- fix conflicting short options for `inject_secrets.sh`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: aiohttp, requests, httpx, certifi, flask)*

------
https://chatgpt.com/codex/tasks/task_e_685365cfed3483289543a1871d41ee3e