### PR TITLE
Merge docs and add tests

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,8 +5,7 @@
 This directory contains all technical and operational documentation for the Sophia AI platform. Documents are organized by category for easy navigation.
 
 ## 🔐 Secret Management (CRITICAL)
-- **[SECRET_MANAGEMENT_GUIDE.md](SECRET_MANAGEMENT_GUIDE.md)** - **START HERE** for all secret-related operations
-- **[GITHUB_SECRETS_SETUP.md](GITHUB_SECRETS_SETUP.md)** - GitHub-specific secret configuration
+- **[SECRET_MANAGEMENT_OVERVIEW.md](SECRET_MANAGEMENT_OVERVIEW.md)** - **START HERE** for all secret-related operations
 
 ## 🚀 Deployment & Operations
 - **[DEPLOYMENT_GUIDE.md](../DEPLOYMENT_GUIDE.md)** - Complete deployment instructions

--- a/docs/SECRET_MANAGEMENT_OVERVIEW.md
+++ b/docs/SECRET_MANAGEMENT_OVERVIEW.md
@@ -1,0 +1,12 @@
+# Sophia AI - Unified Secret Management Overview
+
+This document consolidates information from `SECRET_MANAGEMENT_GUIDE.md` and `SECRETS_MANAGEMENT_IMPLEMENTATION.md`.
+The Sophia platform manages all secrets through **GitHub Organization Secrets** synchronized to **Pulumi ESC**. The backend automatically loads secrets from ESC, removing the need for `.env` files or manual configuration.
+
+## Key Points
+- Secrets are stored in the `ai-cherry` GitHub organization and automatically synced to Pulumi ESC.
+- Scripts in the `scripts/` directory help configure organization or repository secrets.
+- `configure_pulumi_esc.sh` manages ESC environments and can import, sync and list secrets.
+- After setup, running `backend/main.py` uses the synced secrets without additional steps.
+
+Refer to the scripts mentioned above for usage examples and command options.

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,5 @@
+export default {
+  testEnvironment: 'jsdom',
+  moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx'],
+  transform: {},
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
@@ -70,7 +71,13 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
     "tw-animate-css": "^1.2.9",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "jest": "^29.6.3",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.1.5"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
   },
   "packageManager": "pnpm@10.4.1+sha512.c753b6c3ad7afa13af388fa6d808035a008e30ea9993f58c6663e2bc5ff21679aa834db094987129aa4d488b86df57f7b634981b2f827cdcacc698cc0cfb88af"
 }

--- a/frontend/src/components/design-system/buttons/Button.test.jsx
+++ b/frontend/src/components/design-system/buttons/Button.test.jsx
@@ -1,0 +1,16 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import Button from './Button.jsx';
+
+describe('Button component', () => {
+  it('renders children and responds to click', () => {
+    const onClick = jest.fn();
+    render(<Button onClick={onClick}>Click me</Button>);
+    fireEvent.click(screen.getByText('Click me'));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('shows loader when loading', () => {
+    const { container } = render(<Button loading>Load</Button>);
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/hooks/use-mobile.test.js
+++ b/frontend/src/hooks/use-mobile.test.js
@@ -1,0 +1,27 @@
+import { renderHook, act } from '@testing-library/react';
+import { useIsMobile } from './use-mobile';
+
+function setupMatchMedia() {
+  let listener = null;
+  window.matchMedia = jest.fn().mockImplementation(() => ({
+    matches: window.innerWidth < 768,
+    addEventListener: (_evt, cb) => { listener = cb; },
+    removeEventListener: jest.fn(),
+  }));
+  return () => listener && listener();
+}
+
+describe('useIsMobile', () => {
+  it('detects viewport changes', () => {
+    window.innerWidth = 1000;
+    const trigger = setupMatchMedia();
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+
+    act(() => {
+      window.innerWidth = 500;
+      trigger();
+    });
+    expect(result.current).toBe(true);
+  });
+});

--- a/tests/api/test_v1_protected.py
+++ b/tests/api/test_v1_protected.py
@@ -1,0 +1,19 @@
+from fastapi.testclient import TestClient
+from backend.main import app
+from backend.core import security
+
+client = TestClient(app)
+
+VALID_KEY = next(iter(security.VALID_API_KEYS))
+
+
+def test_dashboard_metrics_with_key():
+    resp = client.get('/api/v1/dashboard/metrics', headers={security.API_KEY_NAME: VALID_KEY})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert 'revenue_growth' in data
+
+
+def test_dashboard_metrics_missing_key():
+    resp = client.get('/api/v1/dashboard/metrics')
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- consolidate secrets management docs
- add Jest setup and tests for hooks/components
- test API auth for FastAPI dashboard endpoints

## Testing
- `pnpm test -- -w 1` *(fails: jest not found)*
- `pytest tests/api/test_v1_protected.py -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6856f4ba5ba4832885f761e3fa384acc