### PR TITLE
Implement axios services with WebSocket manager

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,6 +54,7 @@
     "react-resizable-panels": "^3.0.2",
     "react-router-dom": "^7.6.1",
     "recharts": "^2.15.3",
+    "axios": "^1.6.5",
     "sonner": "^2.0.3",
     "tailwind-merge": "^3.3.0",
     "tailwindcss": "^4.1.7",

--- a/frontend/src/components/dashboard/DashboardLayout.jsx
+++ b/frontend/src/components/dashboard/DashboardLayout.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { 
   DollarSign, 
   Users, 
@@ -15,6 +15,7 @@ import GlassCard from '../design-system/cards/GlassCard';
 import Button from '../design-system/buttons/Button';
 import { cn } from '@/lib/utils';
 import api from '../../services/api';
+import useCompanyMetrics from '../../hooks/use-company-metrics';
 import NaturalLanguageInterface from '../NaturalLanguageInterface';
 
 // Tab configuration
@@ -27,34 +28,7 @@ const TABS = [
 
 const DashboardLayout = () => {
   const [activeTab, setActiveTab] = useState('overview');
-  const [metrics, setMetrics] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-
-  // Fetch metrics from backend
-  useEffect(() => {
-    fetchMetrics();
-  }, []);
-
-  const fetchMetrics = async () => {
-    try {
-      setLoading(true);
-      const data = await api.getCompanyMetrics();
-      setMetrics(data);
-      setError(null);
-    } catch (err) {
-      setError(err.message);
-      // Use mock data for demonstration
-      setMetrics({
-        revenue: { value: '$331,000', change: '+18.5%', trend: 'up' },
-        customers: { value: '1,247', change: '+12.3%', trend: 'up' },
-        pipeline: { value: '$2.4M', change: '+23.1%', trend: 'up' },
-        healthScore: { value: '92%', change: '+5.2%', trend: 'up' },
-      });
-    } finally {
-      setLoading(false);
-    }
-  };
+  const { data: metrics, loading, error } = useCompanyMetrics();
 
   const renderTabContent = () => {
     switch (activeTab) {
@@ -80,6 +54,9 @@ const DashboardLayout = () => {
       
       <main className="pt-20">
         <div className="max-w-7xl mx-auto px-6 py-8">
+          {error && (
+            <div className="mb-4 text-red-500">Failed to load metrics</div>
+          )}
           {/* KPI Cards */}
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
             <MetricCard

--- a/frontend/src/components/dashboard/KPIMetrics.tsx
+++ b/frontend/src/components/dashboard/KPIMetrics.tsx
@@ -1,24 +1,16 @@
-import React, { useState, useEffect } from 'react';
-// import { getDashboardMetrics } from '../../services/api_v1';
+import React from 'react';
+import useMetrics from '../../hooks/use-metrics';
 
 const KPIMetrics: React.FC = () => {
-    // const [metrics, setMetrics] = useState(null);
+    const { data: metrics, loading, error } = useMetrics();
 
-    // useEffect(() => {
-    //     const fetchMetrics = async () => {
-    //         const data = await getDashboardMetrics();
-    //         setMetrics(data);
-    //     };
-    //     fetchMetrics();
-    // }, []);
+    if (loading) {
+        return <p>Loading metrics...</p>;
+    }
 
-    // Placeholder data until API service is created
-    const metrics = {
-        revenue_growth: 15.3,
-        client_health_score: 87.5,
-        sales_efficiency: 92.1,
-        ai_task_completion_rate: 98.9,
-    };
+    if (error || !metrics) {
+        return <p className="text-red-500">Failed to load metrics</p>;
+    }
 
     return (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">

--- a/frontend/src/components/dashboard/RealTimeUpdates.tsx
+++ b/frontend/src/components/dashboard/RealTimeUpdates.tsx
@@ -1,18 +1,22 @@
 import React from 'react';
+import useRealTimeEvents from '../../hooks/use-real-time-events';
 
 const RealTimeUpdates: React.FC = () => {
+    const { events, status } = useRealTimeEvents();
+
     return (
         <div className="bg-white p-6 rounded-lg shadow">
             <h3 className="text-xl font-bold mb-4">Real-Time Events</h3>
+            {status !== 'connected' && (
+                <p className="text-sm text-gray-500">Connecting...</p>
+            )}
             <div className="space-y-3 text-sm">
-                <div className="flex items-start">
-                    <span className="text-green-500 w-5 h-5 mr-3"><i className="fas fa-check-circle"></i></span>
-                    <p><span className="font-bold">New Deal Closed:</span> Acme Corp - $250k ARR</p>
-                </div>
-                <div className="flex items-start">
-                     <span className="text-red-500 w-5 h-5 mr-3"><i className="fas fa-exclamation-triangle"></i></span>
-                    <p><span className="font-bold">High-Risk Call:</span> Innovate Inc. mentioned competitor "SynergySoft".</p>
-                </div>
+                {events.map((evt, idx) => (
+                    <div key={idx} className="flex items-start">
+                        <span className="text-green-500 w-5 h-5 mr-3"><i className="fas fa-bolt"></i></span>
+                        <p>{evt.message || JSON.stringify(evt)}</p>
+                    </div>
+                ))}
             </div>
         </div>
     );

--- a/frontend/src/hooks/use-company-metrics.js
+++ b/frontend/src/hooks/use-company-metrics.js
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import api from '../services/api';
+
+export default function useCompanyMetrics() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchData() {
+      try {
+        setLoading(true);
+        const res = await api.getCompanyMetrics();
+        if (!cancelled) {
+          setData(res);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err.message);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+    fetchData();
+    return () => { cancelled = true; };
+  }, []);
+
+  return { data, loading, error };
+}

--- a/frontend/src/hooks/use-metrics.js
+++ b/frontend/src/hooks/use-metrics.js
@@ -1,0 +1,36 @@
+import { useState, useEffect } from 'react';
+import api from '../services/api';
+
+export default function useMetrics() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchMetrics() {
+      try {
+        setLoading(true);
+        const res = await api.getDashboardMetrics();
+        if (!cancelled) {
+          setData(res);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+    fetchMetrics();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { data, loading, error };
+}

--- a/frontend/src/hooks/use-real-time-events.js
+++ b/frontend/src/hooks/use-real-time-events.js
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import wsManager from '../services/WebSocketManager';
+
+export default function useRealTimeEvents() {
+  const [events, setEvents] = useState([]);
+  const [status, setStatus] = useState('connecting');
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const socket = wsManager.connect();
+    const handleMessage = (data) => {
+      setEvents((prev) => [data, ...prev]);
+    };
+    const handleOpen = () => setStatus('connected');
+    const handleClose = () => setStatus('disconnected');
+    const handleError = (e) => {
+      setStatus('error');
+      setError(e);
+    };
+    socket.addEventListener('open', handleOpen);
+    socket.addEventListener('close', handleClose);
+    socket.addEventListener('error', handleError);
+    wsManager.subscribe(handleMessage);
+    return () => {
+      socket.removeEventListener('open', handleOpen);
+      socket.removeEventListener('close', handleClose);
+      socket.removeEventListener('error', handleError);
+      wsManager.unsubscribe(handleMessage);
+    };
+  }, []);
+
+  return { events, status, error };
+}

--- a/frontend/src/services/WebSocketManager.js
+++ b/frontend/src/services/WebSocketManager.js
@@ -1,0 +1,38 @@
+class WebSocketManager {
+  constructor(url = (import.meta.env.VITE_WS_URL || 'ws://localhost:5001/ws')) {
+    this.url = url;
+    this.socket = null;
+    this.listeners = new Set();
+  }
+
+  connect() {
+    if (this.socket) {
+      return this.socket;
+    }
+    this.socket = new WebSocket(this.url);
+    this.socket.addEventListener('message', (e) => {
+      let data;
+      try { data = JSON.parse(e.data); } catch { data = e.data; }
+      this.listeners.forEach((cb) => cb(data));
+    });
+    this.socket.addEventListener('close', () => {
+      this.socket = null;
+    });
+    return this.socket;
+  }
+
+  subscribe(callback) {
+    this.listeners.add(callback);
+    this.connect();
+  }
+
+  unsubscribe(callback) {
+    this.listeners.delete(callback);
+    if (!this.listeners.size && this.socket) {
+      this.socket.close();
+      this.socket = null;
+    }
+  }
+}
+
+export default new WebSocketManager();

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,142 +1,100 @@
-// API Service Layer for Sophia AI
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:5001/api';
+import apiClient from './apiClient.js';
 
 class ApiService {
-  constructor() {
-    this.baseURL = API_BASE_URL;
-    this.token = localStorage.getItem('auth_token');
+  async request(method, endpoint, data = null, config = {}) {
+    const response = await apiClient({ url: endpoint, method, data, ...config });
+    return response.data;
   }
 
-  // Helper method for API requests
-  async request(endpoint, options = {}) {
-    const url = `${this.baseURL}${endpoint}`;
-    const config = {
-      ...options,
-      headers: {
-        'Content-Type': 'application/json',
-        ...options.headers,
-      },
-    };
-
-    // Add auth token if available
-    if (this.token) {
-      config.headers['Authorization'] = `Bearer ${this.token}`;
-    }
-
-    try {
-      const response = await fetch(url, config);
-      
-      if (!response.ok) {
-        throw new Error(`API Error: ${response.statusText}`);
-      }
-      
-      return await response.json();
-    } catch (error) {
-      console.error('API Request failed:', error);
-      throw error;
-    }
-  }
-
-  // Authentication
   async login(email, password) {
-    const response = await this.request('/auth/login', {
-      method: 'POST',
-      body: JSON.stringify({ email, password }),
-    });
-    
-    if (response.token) {
-      this.token = response.token;
-      localStorage.setItem('auth_token', response.token);
+    const data = await this.request('post', '/auth/login', { email, password });
+    if (data.token) {
+      localStorage.setItem('auth_token', data.token);
     }
-    
-    return response;
+    return data;
   }
 
   async logout() {
-    this.token = null;
     localStorage.removeItem('auth_token');
   }
 
   // Company Metrics
-  async getCompanyMetrics() {
-    return this.request('/company/metrics');
+  getCompanyMetrics() {
+    return this.request('get', '/company/metrics');
   }
 
-  async getRevenueData(period = 'monthly') {
-    return this.request(`/company/revenue?period=${period}`);
+  getDashboardMetrics() {
+    return this.request('get', '/dashboard/metrics');
   }
 
-  async getCustomerMetrics() {
-    return this.request('/company/customers');
+  getRevenueData(period = 'monthly') {
+    return this.request('get', `/company/revenue?period=${period}`);
   }
 
-  async getHealthScore() {
-    return this.request('/company/health-score');
+  getCustomerMetrics() {
+    return this.request('get', '/company/customers');
+  }
+
+  getHealthScore() {
+    return this.request('get', '/company/health-score');
   }
 
   // Strategy
-  async getStrategyInsights() {
-    return this.request('/strategy/insights');
+  getStrategyInsights() {
+    return this.request('get', '/strategy/insights');
   }
 
-  async getGrowthOpportunities() {
-    return this.request('/strategy/growth-opportunities');
+  getGrowthOpportunities() {
+    return this.request('get', '/strategy/growth-opportunities');
   }
 
-  async getMarketAnalysis() {
-    return this.request('/strategy/market-analysis');
+  getMarketAnalysis() {
+    return this.request('get', '/strategy/market-analysis');
   }
 
   // Operations
-  async getOperationalMetrics() {
-    return this.request('/operations/metrics');
+  getOperationalMetrics() {
+    return this.request('get', '/operations/metrics');
   }
 
-  async getWorkflows() {
-    return this.request('/operations/workflows');
+  getWorkflows() {
+    return this.request('get', '/operations/workflows');
   }
 
-  async getSystemStatus() {
-    return this.request('/operations/status');
+  getSystemStatus() {
+    return this.request('get', '/operations/status');
   }
 
   // AI Insights
-  async getAIInsights() {
-    return this.request('/ai/insights');
+  getAIInsights() {
+    return this.request('get', '/ai/insights');
   }
 
-  async getPredictions() {
-    return this.request('/ai/predictions');
+  getPredictions() {
+    return this.request('get', '/ai/predictions');
   }
 
-  async getRecommendations() {
-    return this.request('/ai/recommendations');
+  getRecommendations() {
+    return this.request('get', '/ai/recommendations');
   }
 
   // Property Management
-  async getPropertyData() {
-    return this.request('/property/units');
+  getPropertyData() {
+    return this.request('get', '/property/units');
   }
 
-  async searchUnits(filters) {
-    return this.request('/property/search', {
-      method: 'POST',
-      body: JSON.stringify(filters),
-    });
+  searchUnits(filters) {
+    return this.request('post', '/property/search', filters);
   }
 
   // Knowledge Base
-  async searchKnowledge(query) {
-    return this.request('/knowledge/search', {
-      method: 'POST',
-      body: JSON.stringify({ query }),
-    });
+  searchKnowledge(query) {
+    return this.request('post', '/knowledge/search', { query });
   }
 
-  async getKnowledgeStats() {
-    return this.request('/knowledge/stats');
+  getKnowledgeStats() {
+    return this.request('get', '/knowledge/stats');
   }
 }
 
-// Export singleton instance
-export default new ApiService(); 
+export default new ApiService();

--- a/frontend/src/services/apiClient.js
+++ b/frontend/src/services/apiClient.js
@@ -1,0 +1,23 @@
+import axios from 'axios';
+
+const apiClient = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:5001/api',
+});
+
+apiClient.interceptors.request.use((config) => {
+  const token = localStorage.getItem('auth_token');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    console.error('API Error:', error);
+    return Promise.reject(error);
+  }
+);
+
+export default apiClient;


### PR DESCRIPTION
## Summary
- add axios-based API client with interceptors
- create WebSocket manager service
- fetch metrics via new hooks
- use WebSocket events for real-time updates
- surface loading and error states in dashboard hooks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pulumi.automation, httpx, aiohttp, certifi, flask, backend modules)*

------
https://chatgpt.com/codex/tasks/task_e_6856f4b5e3208328ba9ea83ee3c8aac0