### PR TITLE
Enforce Pulumi token in secret managers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,7 @@ cleanup_backup_*/
 **/*key*
 pulumi-access-token*
 PULUMI_ACCESS_TOKEN*
+!scripts/setup_all_secrets_once.py
 
 # Pulumi state and config (may contain secrets)
 Pulumi.*.yaml

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ A comprehensive AI platform with MCP (Model Context Protocol) integration, deplo
 # Clone the repository
 git clone https://github.com/ai-cherry/sophia-main.git
 cd sophia-main
+# Set Pulumi token (required for all setup scripts)
+export PULUMI_ACCESS_TOKEN=your_token_here
 
 # Deploy the platform
 ./deploy_sophia_platform.sh

--- a/backend/core/pulumi_esc.py
+++ b/backend/core/pulumi_esc.py
@@ -76,7 +76,7 @@ class ESCClient:
         self.initialized = False
 
         if not self.access_token:
-            logger.warning("PULUMI_ACCESS_TOKEN not found in environment variables")
+            raise ValueError("PULUMI_ACCESS_TOKEN environment variable is required")
 
     async def _ensure_session(self) -> None:
         """Ensure aiohttp session is created with proper error handling"""

--- a/backend/core/secure_environment_validator.py
+++ b/backend/core/secure_environment_validator.py
@@ -183,7 +183,7 @@ class SecureEnvironmentValidator:
             ),
             "PULUMI_ACCESS_TOKEN": ValidationRule(
                 name="PULUMI_ACCESS_TOKEN",
-                required=False,
+                required=True,
                 secret_type=SecretType.TOKEN,
                 description="Pulumi access token",
             ),

--- a/backend/integrations/pulumi_mcp_client.py
+++ b/backend/integrations/pulumi_mcp_client.py
@@ -37,6 +37,8 @@ class PulumiMCPClient:
 
     def __init__(self, config_path: str = "config/pulumi-mcp.json"):
         self.config = self._load_config(config_path)
+        if not self.config.api_token:
+            raise ValueError("PULUMI_ACCESS_TOKEN environment variable is required")
         self.session = None
         self.audit_logger = self._setup_audit_logger()
 
@@ -44,7 +46,7 @@ class PulumiMCPClient:
         """Load configuration from file or environment"""
         config_data = {
             "base_url": os.getenv("PULUMI_MCP_URL", "http://pulumi-mcp-server:9001"),
-            "api_token": os.getenv("PULUMI_ACCESS_TOKEN", ""),
+            "api_token": os.getenv("PULUMI_ACCESS_TOKEN"),
             "organization": os.getenv("PULUMI_ORG", "sophia-ai"),
             "project": os.getenv("PULUMI_PROJECT", "sophia"),
             "allowed_stacks": ["dev", "staging", "prod"],

--- a/docs/SECRET_MANAGEMENT_GUIDE.md
+++ b/docs/SECRET_MANAGEMENT_GUIDE.md
@@ -63,13 +63,16 @@ cd sophia-main
 # 2. Set Pulumi organization
 export PULUMI_ORG=scoobyjava-org
 
-# 3. Run permanent solution setup
-python scripts/setup_permanent_secrets_solution.py
+# 3. Set Pulumi access token
+export PULUMI_ACCESS_TOKEN=your_token_here
 
-# 4. Test everything works
+# 4. Sync secrets from Pulumi ESC
+python scripts/setup_all_secrets_once.py
+
+# 5. Test everything works
 python scripts/test_permanent_solution.py
 
-# 5. Start developing - all secrets automatically available!
+# 6. Start developing - all secrets automatically available!
 python backend/main.py
 ```
 

--- a/docs/cursor_ai_integration.md
+++ b/docs/cursor_ai_integration.md
@@ -50,8 +50,11 @@ cd sophia-main
 # Set Pulumi organization
 export PULUMI_ORG=scoobyjava-org
 
-# Run permanent solution setup
-python scripts/setup_permanent_secrets_solution.py
+# Set Pulumi access token
+export PULUMI_ACCESS_TOKEN=your_token_here
+
+# Sync secrets from Pulumi ESC
+python scripts/setup_all_secrets_once.py
 
 # Test everything works
 python scripts/test_permanent_solution.py

--- a/infrastructure/pulumi_esc.py
+++ b/infrastructure/pulumi_esc.py
@@ -10,9 +10,16 @@ logger = logging.getLogger(__name__)
 
 
 class PulumiESCManager:
-    """Simple placeholder for Pulumi ESC Manager."""
+    """Simple placeholder for Pulumi ESC Manager.
+
+    This manager now enforces that ``PULUMI_ACCESS_TOKEN`` is set so that any
+    consumer has authenticated access to Pulumi ESC.
+    """
 
     def __init__(self):
+        self.access_token = os.getenv("PULUMI_ACCESS_TOKEN")
+        if not self.access_token:
+            raise ValueError("PULUMI_ACCESS_TOKEN environment variable is required")
         self.initialized = False
 
     async def initialize(self):

--- a/scripts/setup_all_secrets_once.py
+++ b/scripts/setup_all_secrets_once.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""One-time secret setup script.
+
+This script validates that `PULUMI_ACCESS_TOKEN` is set and then
+synchronizes secrets from Pulumi ESC into local configuration files.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_ENV = f"{os.getenv('PULUMI_ORG', 'scoobyjava-org')}/default/sophia-ai-production"
+
+
+def require_pulumi_token() -> str:
+    token = os.getenv("PULUMI_ACCESS_TOKEN")
+    if not token:
+        sys.stderr.write("Error: PULUMI_ACCESS_TOKEN environment variable is required\n")
+        sys.exit(1)
+    return token
+
+
+def ensure_pulumi_cli():
+    try:
+        subprocess.run(["pulumi", "version"], capture_output=True, check=True)
+    except FileNotFoundError:
+        sys.stderr.write("Pulumi CLI not found. Please install Pulumi.\n")
+        sys.exit(1)
+    except subprocess.CalledProcessError as e:
+        sys.stderr.write(f"Failed to run Pulumi CLI: {e}\n")
+        sys.exit(1)
+
+
+def load_esc_config(environment: str) -> dict:
+    cmd = ["pulumi", "env", "open", environment, "--format", "json"]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        return json.loads(result.stdout)
+    except subprocess.CalledProcessError as e:
+        sys.stderr.write(f"Failed to load Pulumi ESC environment: {e.stderr}\n")
+        sys.exit(1)
+
+
+def write_env_file(env_vars: dict) -> None:
+    path = Path(".env")
+    lines = [f"{k}={v}" for k, v in env_vars.items()]
+    path.write_text("\n".join(lines))
+    print(f"✅ Wrote {path}")
+
+
+def write_config(values: dict) -> None:
+    path = Path("mcp_config.json")
+    with path.open("w") as f:
+        json.dump(values, f, indent=2)
+    print(f"✅ Wrote {path}")
+
+
+def main() -> None:
+    require_pulumi_token()
+    ensure_pulumi_cli()
+
+    environment = os.getenv("PULUMI_ESC_ENV", DEFAULT_ENV)
+    print(f"Syncing secrets from Pulumi ESC: {environment}")
+
+    config = load_esc_config(environment)
+    env_vars = config.get("environmentVariables", {})
+    values = config.get("values", {})
+
+    if env_vars:
+        write_env_file(env_vars)
+    if values:
+        write_config(values)
+
+    print("Secrets synchronized from Pulumi ESC.\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- require `PULUMI_ACCESS_TOKEN` for placeholder Pulumi ESC manager and core ESC client
- enforce token for Pulumi MCP client
- mark token as required in environment validator
- add `scripts/setup_all_secrets_once.py` to sync secrets from Pulumi ESC
- document token setup in README, Secret Management Guide and Cursor AI guide
- ignore pattern updated to allow the new script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and other collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856f60d720483288942370c25af10f6