### PR TITLE
Add setup script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ A comprehensive AI platform with MCP (Model Context Protocol) integration, deplo
 git clone https://github.com/ai-cherry/sophia-main.git
 cd sophia-main
 
+# Install Python dependencies
+pip install -r requirements.txt
+# Or use the optional setup script
+# ./setup.sh
+
 # Deploy the platform
 ./deploy_sophia_platform.sh
 ```
@@ -75,6 +80,8 @@ External APIs → Airbyte → Snowflake → Vector Processing → Pinecone → A
 ```bash
 # Install dependencies
 pip install -r requirements.txt
+# Or run the helper script which installs Python packages for you
+# ./setup.sh
 npm install
 
 # Configure environment

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Simple setup script for Sophia AI
+# Installs required Python packages
+
+set -e
+
+if [ ! -f requirements.txt ]; then
+  echo "requirements.txt not found. Please ensure it exists before running this script." >&2
+  exit 1
+fi
+
+pip install -r requirements.txt
+
+echo "Dependencies installed."
+


### PR DESCRIPTION
## Summary
- emphasize requirements install in README Quick Start
- add note about setup script to local setup instructions
- provide setup.sh for installing Python packages before running other commands

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6856f60dad4c83289ed14ada30b90dd2