### PR TITLE
Add configuration validation utilities

### DIFF
--- a/scripts/validate_sophia_config.py
+++ b/scripts/validate_sophia_config.py
@@ -1,5 +1,9 @@
 """Validate Sophia AI configuration before deployment"""
 
+import json
+import os
+from pathlib import Path
+
 
 def validate_sophia_ai_config():
     """Validate all Sophia AI configuration requirements"""
@@ -34,24 +38,110 @@ def validate_service_integrations():
 
 # Placeholder validation helpers
 
-def validate_esc_environment():
-    pass
+def validate_esc_environment() -> bool:
+    """Ensure Pulumi ESC environment variables are properly defined."""
+    required_vars = ["PULUMI_ACCESS_TOKEN", "PULUMI_ORG", "PULUMI_ESC_ENV"]
+
+    missing = [var for var in required_vars if not os.getenv(var)]
+    if missing:
+        raise EnvironmentError(f"Missing environment variables: {', '.join(missing)}")
+
+    env_path = os.getenv("PULUMI_ESC_ENV")
+    if env_path and env_path.count("/") < 2:
+        raise ValueError("PULUMI_ESC_ENV must be in 'org/project/stack' format")
+
+    return True
 
 
-def validate_lambda_labs_config():
-    pass
+def validate_lambda_labs_config() -> bool:
+    """Validate Lambda Labs configuration."""
+    api_key = os.getenv("LAMBDA_LABS_API_KEY")
+    if not api_key:
+        raise EnvironmentError("LAMBDA_LABS_API_KEY is not set")
+    if api_key.startswith("your_"):
+        raise ValueError("LAMBDA_LABS_API_KEY appears to be a placeholder value")
+    return True
 
 
-def validate_mcp_servers():
-    pass
+def validate_mcp_servers() -> list[dict]:
+    """Validate MCP server configuration file."""
+    path = Path("mcp-config/mcp_servers.json")
+    if not path.exists():
+        raise FileNotFoundError(f"{path} not found")
+
+    with path.open("r", encoding="utf-8") as f:
+        servers = json.load(f)
+
+    if not isinstance(servers, list) or not servers:
+        raise ValueError("mcp_servers.json must contain a list of server configs")
+
+    required_names = {"snowflake", "pulumi", "ai_memory"}
+    names = set()
+    for server in servers:
+        if not isinstance(server, dict):
+            raise ValueError("Each MCP server entry must be a dictionary")
+        if "name" not in server or "url" not in server:
+            raise ValueError("MCP server entries require 'name' and 'url'")
+        if not str(server["url"]).startswith(("http://", "https://")):
+            raise ValueError(f"Invalid URL for MCP server {server.get('name')}")
+        names.add(server["name"])
+
+    if not required_names.issubset(names):
+        missing = required_names - names
+        raise ValueError(f"Missing MCP servers: {', '.join(sorted(missing))}")
+
+    return servers
 
 
-def validate_business_intelligence_pipeline():
-    pass
+def validate_business_intelligence_pipeline() -> bool:
+    """Validate environment for the business intelligence pipeline."""
+    required_env = [
+        "POSTGRES_HOST",
+        "POSTGRES_PASSWORD",
+        "REDIS_HOST",
+    ]
+
+    missing = [var for var in required_env if not os.getenv(var)]
+    if missing:
+        raise EnvironmentError(
+            f"Missing required BI pipeline variables: {', '.join(missing)}"
+        )
+
+    pipeline_path = Path("backend/pipeline/data_pipeline_architecture.py")
+    if not pipeline_path.exists():
+        raise FileNotFoundError("Data pipeline module not found")
+
+    return True
 
 
-def validate_service_config(service: str):
-    pass
+def validate_service_config(service: str) -> bool:
+    """Check that required environment variables exist for a service."""
+    service_envs = {
+        "arize": ["ARIZE_API_KEY", "ARIZE_SPACE_ID"],
+        "openrouter": ["OPENROUTER_API_KEY"],
+        "portkey": ["PORTKEY_API_KEY"],
+        "huggingface": ["HUGGINGFACE_API_KEY"],
+        "together_ai": ["TOGETHER_API_KEY"],
+        "apify": ["APIFY_API_TOKEN"],
+        "phantombuster": ["PHANTOM_BUSTER_KEY"],
+        "twingly": ["TWINGLY_API_KEY"],
+        "tavily": ["TAVILY_API_KEY"],
+        "zenrows": ["ZENROWS_API_KEY"],
+        "lambda_labs": ["LAMBDA_LABS_API_KEY"],
+        "docker": [],
+        "pulumi": ["PULUMI_ACCESS_TOKEN"],
+        "snowflake": ["SNOWFLAKE_USER", "SNOWFLAKE_PASSWORD", "SNOWFLAKE_ACCOUNT"],
+        "pinecone": ["PINECONE_API_KEY"],
+    }
+
+    required = service_envs.get(service, [])
+    missing = [var for var in required if not os.getenv(var)]
+    if missing:
+        raise EnvironmentError(
+            f"Service '{service}' missing environment vars: {', '.join(missing)}"
+        )
+
+    return True
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_validate_config.py
+++ b/tests/unit/test_validate_config.py
@@ -1,0 +1,63 @@
+import os
+import importlib.util
+from pathlib import Path
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "validate_sophia_config.py"
+spec = importlib.util.spec_from_file_location("validate_sophia_config", SCRIPT_PATH)
+validate_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(validate_module)
+
+validate_esc_environment = validate_module.validate_esc_environment
+validate_lambda_labs_config = validate_module.validate_lambda_labs_config
+validate_mcp_servers = validate_module.validate_mcp_servers
+validate_business_intelligence_pipeline = validate_module.validate_business_intelligence_pipeline
+validate_service_config = validate_module.validate_service_config
+
+
+def test_validate_esc_environment_success(monkeypatch):
+    monkeypatch.setenv("PULUMI_ACCESS_TOKEN", "token")
+    monkeypatch.setenv("PULUMI_ORG", "org")
+    monkeypatch.setenv("PULUMI_ESC_ENV", "org/project/stack")
+    assert validate_esc_environment() is True
+
+
+def test_validate_esc_environment_missing(monkeypatch):
+    monkeypatch.delenv("PULUMI_ACCESS_TOKEN", raising=False)
+    monkeypatch.setenv("PULUMI_ORG", "org")
+    monkeypatch.setenv("PULUMI_ESC_ENV", "org/project/stack")
+    with pytest.raises(EnvironmentError):
+        validate_esc_environment()
+
+
+def test_validate_lambda_labs_config(monkeypatch):
+    monkeypatch.setenv("LAMBDA_LABS_API_KEY", "realkey")
+    assert validate_lambda_labs_config() is True
+
+    monkeypatch.setenv("LAMBDA_LABS_API_KEY", "your_lambda_labs_api_key")
+    with pytest.raises(ValueError):
+        validate_lambda_labs_config()
+
+
+def test_validate_mcp_servers():
+    servers = validate_mcp_servers()
+    assert isinstance(servers, list)
+    assert any(s["name"] == "pulumi" for s in servers)
+
+
+def test_validate_business_intelligence_pipeline(monkeypatch):
+    monkeypatch.setenv("POSTGRES_HOST", "localhost")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "pass")
+    monkeypatch.setenv("REDIS_HOST", "localhost")
+    assert validate_business_intelligence_pipeline() is True
+
+
+def test_validate_service_config(monkeypatch):
+    monkeypatch.setenv("SNOWFLAKE_USER", "user")
+    monkeypatch.setenv("SNOWFLAKE_PASSWORD", "pw")
+    monkeypatch.setenv("SNOWFLAKE_ACCOUNT", "acc")
+    assert validate_service_config("snowflake") is True
+
+    monkeypatch.delenv("SNOWFLAKE_USER")
+    with pytest.raises(EnvironmentError):
+        validate_service_config("snowflake")


### PR DESCRIPTION
## Summary
- implement config validation helpers
- add unit tests for new validation helpers

## Testing
- `pytest -q tests/unit/test_validate_config.py`

------
https://chatgpt.com/codex/tasks/task_e_6856fa631cd08328839d8c8aa11ce02a