### PR TITLE
Add secret export workflow

### DIFF
--- a/.github/workflows/sophia_secrets_export.yml
+++ b/.github/workflows/sophia_secrets_export.yml
@@ -1,0 +1,71 @@
+name: Export GitHub Secrets to Pulumi ESC
+
+on:
+  schedule:
+    # Weekly at 03:00 UTC every Monday
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+jobs:
+  sync-secrets:
+    runs-on: ubuntu-latest
+    env:
+      PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Pulumi CLI
+        run: |
+          curl -fsSL https://get.pulumi.com | sh
+          echo "$HOME/.pulumi/bin" >> "$GITHUB_PATH"
+
+      - name: Sync AI intelligence secrets
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          LAMBDA_LABS_API_KEY: ${{ secrets.LAMBDA_LABS_API_KEY }}
+        run: |
+          set -euo pipefail
+          trap 'echo "::error::Failed to sync AI intelligence secrets"' ERR
+          pulumi esc secrets set sophia-ai/production ai.openai.api_key "$OPENAI_API_KEY" --secret
+          pulumi esc secrets set sophia-ai/production ai.anthropic.api_key "$ANTHROPIC_API_KEY" --secret
+          pulumi esc secrets set sophia-ai/production ai.lambda_labs.api_key "$LAMBDA_LABS_API_KEY" --secret
+
+      - name: Sync Data intelligence secrets
+        env:
+          SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+          SNOWFLAKE_USER: ${{ secrets.SNOWFLAKE_USER }}
+          SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
+          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+        run: |
+          set -euo pipefail
+          trap 'echo "::error::Failed to sync Data intelligence secrets"' ERR
+          pulumi esc secrets set sophia-ai/production data.snowflake.account "$SNOWFLAKE_ACCOUNT" --secret
+          pulumi esc secrets set sophia-ai/production data.snowflake.user "$SNOWFLAKE_USER" --secret
+          pulumi esc secrets set sophia-ai/production data.snowflake.password "$SNOWFLAKE_PASSWORD" --secret
+          pulumi esc secrets set sophia-ai/production data.pinecone.api_key "$PINECONE_API_KEY" --secret
+
+      - name: Sync Infrastructure secrets
+        env:
+          VERCEL_ACCESS_TOKEN: ${{ secrets.VERCEL_ACCESS_TOKEN }}
+          LAMBDA_LABS_API_KEY: ${{ secrets.LAMBDA_LABS_API_KEY }}
+        run: |
+          set -euo pipefail
+          trap 'echo "::error::Failed to sync Infrastructure secrets"' ERR
+          pulumi esc secrets set sophia-ai/production infra.vercel.access_token "$VERCEL_ACCESS_TOKEN" --secret
+          pulumi esc secrets set sophia-ai/production infra.lambda_labs.api_key "$LAMBDA_LABS_API_KEY" --secret
+
+      - name: Sync Business intelligence secrets
+        env:
+          GONG_API_KEY: ${{ secrets.GONG_API_KEY }}
+          GONG_CLIENT_SECRET: ${{ secrets.GONG_CLIENT_SECRET }}
+          HUBSPOT_API_KEY: ${{ secrets.HUBSPOT_API_KEY }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        run: |
+          set -euo pipefail
+          trap 'echo "::error::Failed to sync Business intelligence secrets"' ERR
+          pulumi esc secrets set sophia-ai/production biz.gong.api_key "$GONG_API_KEY" --secret
+          pulumi esc secrets set sophia-ai/production biz.gong.client_secret "$GONG_CLIENT_SECRET" --secret
+          pulumi esc secrets set sophia-ai/production biz.hubspot.api_key "$HUBSPOT_API_KEY" --secret
+          pulumi esc secrets set sophia-ai/production biz.slack.bot_token "$SLACK_BOT_TOKEN" --secret


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to export organization secrets to Pulumi ESC weekly

## Testing
- `pre-commit run --files .github/workflows/sophia_secrets_export.yml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pulumi.automation')*

------
https://chatgpt.com/codex/tasks/task_e_6856fd94179c83288b86ca94e983f967