### PR TITLE
Add MCP and automation documentation

### DIFF
--- a/docs/AUTOMATION_API_WORKFLOW.md
+++ b/docs/AUTOMATION_API_WORKFLOW.md
@@ -1,0 +1,43 @@
+# Sophia AI - Automation API Workflow
+
+This guide explains how Sophia AI orchestrates infrastructure changes through the Pulumi Automation API.
+The `PulumiAgent` communicates with the Pulumi MCP server which in turn invokes Automation API programs inside the `iac-toolkit` container.
+
+## Workflow Overview
+
+```mermaid
+graph LR
+    A[User Command] --> B[PulumiAgent]
+    B --> C[Pulumi MCP Server]
+    C --> D[Automation API Program]
+    D --> E[Cloud Resources]
+    E --> F[Status Back to Agent]
+```
+
+1. **User Command** – A natural language command like `deploy prod` is issued.
+2. **PulumiAgent** – Parses the request and sends an API call to the Pulumi MCP server.
+3. **Pulumi MCP Server** – Runs a Pulumi Automation API program within the `iac-toolkit` container.
+4. **Cloud Resources** – Infrastructure changes are applied using the authenticated credentials from Pulumi ESC.
+5. **Status Back** – Results are returned to the agent and surfaced to the user.
+
+## Example Usage
+
+```python
+from backend.agents.pulumi_agent import PulumiAgent
+
+agent = PulumiAgent()
+result = await agent.handle_command("deploy staging", session_id="abc")
+print(result)
+```
+
+## Troubleshooting
+
+- **Stack fails to deploy** – inspect the container logs with `docker-compose logs pulumi-mcp`.
+- **Permission errors** – confirm the user or service account has the required role as defined in `config/services/pulumi-mcp.json`.
+- **Automation API not found** – ensure the `iac-toolkit` container is running and accessible from the MCP server.
+
+## Maintenance
+
+1. Keep the Pulumi stack configuration files in `infrastructure/` under version control.
+2. Update dependencies inside `iac-toolkit` using `poetry update` when upgrading Pulumi.
+3. Monitor the audit log specified by `audit_log_path` to track all Automation API actions.

--- a/docs/CONTAINER_ARCHITECTURE_DIAGRAMS.md
+++ b/docs/CONTAINER_ARCHITECTURE_DIAGRAMS.md
@@ -1,0 +1,40 @@
+# Sophia AI - Containerized Architecture
+
+The platform runs as a collection of Docker containers orchestrated with Docker Compose.
+The diagram below shows the main services and network connections.
+
+```mermaid
+graph TD
+    subgraph Core
+        api[Sophia API]
+        mcp[MCP Servers]
+        gateway[MCP Gateway]
+    end
+    api --> postgres[(PostgreSQL)]
+    api --> redis[(Redis)]
+    api --> weaviate[(Weaviate)]
+    gateway --> mcp
+    mcp --> iac[IAC Toolkit]
+    api --> nginx[Nginx]
+    prometheus --> api
+    grafana --> prometheus
+```
+
+## Service List
+
+- **sophia-api** – FastAPI application
+- **postgres** – main database
+- **redis** – cache and message bus
+- **weaviate** – vector database
+- **mcp servers** – domain specific MCP containers
+- **mcp-gateway** – routes requests to MCP servers
+- **iac-toolkit** – runs Pulumi Automation API programs
+- **prometheus & grafana** – monitoring stack
+- **nginx** – reverse proxy in production
+
+## Maintenance Tips
+
+- Use `docker-compose ps` to verify all containers are running.
+- Restart individual services with `docker-compose restart <service>`.
+- Remove unused volumes periodically: `docker volume prune`.
+- Check container logs for errors: `docker-compose logs <service>`.

--- a/docs/COPILOT_INTEGRATION_USAGE.md
+++ b/docs/COPILOT_INTEGRATION_USAGE.md
@@ -1,0 +1,37 @@
+# Sophia AI - Copilot Integration Usage
+
+Sophia AI leverages Pulumi's AI‑Copilot to provide automated suggestions when infrastructure operations fail.
+This feature is available through the `PulumiAgent` and the `pulumi_mcp_client`.
+
+## Getting Suggestions
+
+Use the Pulumi agent to request fixes when a command fails:
+
+```python
+from backend.agents.pulumi_agent import PulumiAgent
+
+agent = PulumiAgent()
+result = await agent.handle_command("fix error: resource not found", session_id="123")
+print(result)
+```
+
+The agent collects the most recent error from context and calls `/api/copilot/suggestions` on the Pulumi MCP server.
+
+## Typical Workflow
+
+1. Run a Pulumi command via the agent (e.g. `deploy dev`).
+2. If an error occurs, issue a `fix` command.
+3. Review the Copilot suggestion returned in the response.
+4. Apply the suggestion manually or let the agent attempt an automatic patch.
+
+## Troubleshooting
+
+- **No suggestions returned** – verify `copilot.enabled` is `true` in `config/services/pulumi-mcp.json` and that your Pulumi access token is valid.
+- **Network errors** – check connectivity between the API container and the Pulumi MCP server.
+- **Outdated context** – ensure the session ID used for `fix` matches the one from the failed command.
+
+## Maintenance
+
+- Keep your Pulumi CLI version up to date in the `iac-toolkit` container.
+- Rotate the Pulumi access token stored in GitHub organization secrets when required.
+- Periodically review Copilot responses to improve automation rules.

--- a/docs/MCP_SERVER_API_REFERENCE.md
+++ b/docs/MCP_SERVER_API_REFERENCE.md
@@ -1,0 +1,53 @@
+# Sophia AI - MCP Server API Reference
+
+This document lists the core HTTP endpoints exposed by an MCP server. Endpoints are secured with JWT authentication loaded automatically from Pulumi ESC.
+
+## Base URL
+
+```
+http://<mcp-server-host>:8002
+```
+
+## Endpoints
+
+| Method | Endpoint | Description |
+|-------|----------|-------------|
+| `GET` | `/health` | Server health check |
+| `POST` | `/auth/token` | Obtain JWT token |
+| `POST` | `/tools/<name>` | Execute a registered tool |
+| `POST` | `/resources/<name>` | Access a resource or query data |
+| `GET` | `/metrics` | Prometheus metrics |
+| `GET` | `/docs` | Interactive API docs |
+
+### Tool Invocation Example
+
+```bash
+curl -X POST http://localhost:8002/tools/gong_call_analysis \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"call_id": "12345"}'
+```
+
+### Resource Query Example
+
+```bash
+curl -X POST http://localhost:8002/resources/hubspot_contacts \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"email": "customer@example.com"}'
+```
+
+## Troubleshooting
+
+- **401 Unauthorized** – verify the JWT token from `/auth/token` and ensure the MCP server can access Pulumi ESC.
+- **404 Not Found** – confirm the tool or resource name exists in `mcp_config.json` and the corresponding module is loaded.
+- **Server Unreachable** – check container logs with `docker-compose -f docker-compose.mcp.yml logs <service>` and restart if necessary.
+
+## Maintenance
+
+1. Update the `mcp_config.json` file when adding tools or resources.
+2. Restart the MCP container to apply configuration changes:
+   ```bash
+   docker-compose -f docker-compose.mcp.yml restart <service>
+   ```
+3. Review `/metrics` regularly to monitor usage and performance.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,14 +15,18 @@ This directory contains all technical and operational documentation for the Soph
 - **[SOPHIA_AI_INFRASTRUCTURE_REPORT.md](SOPHIA_AI_INFRASTRUCTURE_REPORT.md)** - Infrastructure overview and capabilities
 - **[SOPHIA_DESIGN_SYSTEM_INTEGRATION.md](SOPHIA_DESIGN_SYSTEM_INTEGRATION.md)** - UI/UX design system guide
 - **[implementation/sophia_technical_architecture.md](implementation/sophia_technical_architecture.md)** - Detailed technical architecture
+- **[CONTAINER_ARCHITECTURE_DIAGRAMS.md](CONTAINER_ARCHITECTURE_DIAGRAMS.md)** - Containerized architecture diagrams
 
 ## 💻 Development
 - **[implementation/sophia_implementation_plan.md](implementation/sophia_implementation_plan.md)** - Implementation roadmap
 - **[implementation/sophia_development_timeline.md](implementation/sophia_development_timeline.md)** - Development milestones
 - **[cursor_ai_integration.md](cursor_ai_integration.md)** - Cursor AI development setup
+- **[COPILOT_INTEGRATION_USAGE.md](COPILOT_INTEGRATION_USAGE.md)** - Using Pulumi Copilot
+- **[AUTOMATION_API_WORKFLOW.md](AUTOMATION_API_WORKFLOW.md)** - Automation API workflow
 
 ## 🔌 Integrations
 - **[mcp_server_documentation.md](mcp_server_documentation.md)** - MCP server configuration
+- **[MCP_SERVER_API_REFERENCE.md](MCP_SERVER_API_REFERENCE.md)** - MCP server API reference
 - **[NATURAL_LANGUAGE_CONTROL_GUIDE.md](NATURAL_LANGUAGE_CONTROL_GUIDE.md)** - Natural language interface guide
 
 ## 🔍 Quick Links
@@ -54,4 +58,4 @@ When adding new documentation:
 ---
 
 **Last Updated:** December 2024
-**Maintained By:** Sophia AI Development Team 
+**Maintained By:** Sophia AI Development Team


### PR DESCRIPTION
## Summary
- document available MCP server APIs
- describe how to use Copilot integration
- outline Automation API workflow
- provide containerized architecture diagrams
- update documentation index

## Testing
- `pre-commit run --files docs/MCP_SERVER_API_REFERENCE.md docs/COPILOT_INTEGRATION_USAGE.md docs/AUTOMATION_API_WORKFLOW.md docs/CONTAINER_ARCHITECTURE_DIAGRAMS.md docs/README.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pulumi.automation')*

------
https://chatgpt.com/codex/tasks/task_e_6856fda6758883289335663b0deafc10