### PR TITLE
Initialize MCP clients using ESC secrets

### DIFF
--- a/mcp-servers/sophia_ai_intelligence/sophia_ai_intelligence_mcp_server.py
+++ b/mcp-servers/sophia_ai_intelligence/sophia_ai_intelligence_mcp_server.py
@@ -1,12 +1,12 @@
 from mcp_base import MCPServer, Tool
-import os
+from backend.integrations.pulumi_esc import SophiaESCManager
 
 class SophiaAIIntelligenceMCPServer(MCPServer):
     """Comprehensive AI intelligence MCP server for Sophia AI"""
 
     def __init__(self):
         super().__init__("sophia_ai_intelligence")
-        # Initialize service clients using ESC values
+        self.esc_manager = SophiaESCManager()
         self.arize_client = self._init_arize_client()
         self.openrouter_client = self._init_openrouter_client()
         self.portkey_client = self._init_portkey_client()
@@ -57,19 +57,56 @@ class SophiaAIIntelligenceMCPServer(MCPServer):
         pass
 
     def _init_arize_client(self):
-        return None
+        try:
+            api_key = self.esc_manager.get_secret("observability.arize_api_key")
+            space_id = self.esc_manager.get_secret("observability.arize_space_id")
+            if not api_key or not space_id:
+                raise ValueError("Missing Arize credentials")
+            return {"api_key": api_key, "space_id": space_id}
+        except Exception as e:
+            self.logger.error(f"Failed to authenticate Arize client: {e}")
+            return None
 
     def _init_openrouter_client(self):
-        return None
+        try:
+            api_key = self.esc_manager.get_secret("ai_services.openrouter_api_key")
+            if not api_key:
+                raise ValueError("Missing OpenRouter API key")
+            return {"api_key": api_key}
+        except Exception as e:
+            self.logger.error(f"Failed to authenticate OpenRouter client: {e}")
+            return None
 
     def _init_portkey_client(self):
-        return None
+        try:
+            api_key = self.esc_manager.get_secret("ai_services.portkey_api_key")
+            config_id = self.esc_manager.get_secret("ai_services.portkey_config_id")
+            if not api_key:
+                raise ValueError("Missing Portkey API key")
+            return {"api_key": api_key, "config_id": config_id}
+        except Exception as e:
+            self.logger.error(f"Failed to authenticate Portkey client: {e}")
+            return None
 
     def _init_huggingface_client(self):
-        return None
+        try:
+            token = self.esc_manager.get_secret("ai_services.huggingface_api_token")
+            if not token:
+                raise ValueError("Missing HuggingFace token")
+            return {"api_token": token}
+        except Exception as e:
+            self.logger.error(f"Failed to authenticate HuggingFace client: {e}")
+            return None
 
     def _init_together_client(self):
-        return None
+        try:
+            api_key = self.esc_manager.get_secret("ai_services.togetherai_api_key")
+            if not api_key:
+                raise ValueError("Missing Together AI key")
+            return {"api_key": api_key}
+        except Exception as e:
+            self.logger.error(f"Failed to authenticate TogetherAI client: {e}")
+            return None
 
 
 if __name__ == "__main__":

--- a/mcp-servers/sophia_data_intelligence/sophia_data_intelligence_mcp_server.py
+++ b/mcp-servers/sophia_data_intelligence/sophia_data_intelligence_mcp_server.py
@@ -1,11 +1,12 @@
 from mcp_base import MCPServer, Tool
+from backend.integrations.pulumi_esc import SophiaESCManager
 
 class SophiaDataIntelligenceMCPServer(MCPServer):
     """Comprehensive data intelligence MCP server for Sophia AI business intelligence"""
 
     def __init__(self):
         super().__init__("sophia_data_intelligence")
-        # Initialize data collection services for business intelligence
+        self.esc_manager = SophiaESCManager()
         self.apify_client = self._init_apify_client()
         self.tavily_client = self._init_tavily_client()
         self.zenrows_client = self._init_zenrows_client()
@@ -52,19 +53,54 @@ class SophiaDataIntelligenceMCPServer(MCPServer):
         pass
 
     def _init_apify_client(self):
-        return None
+        try:
+            token = self.esc_manager.get_secret("research_tools.apify_api_token")
+            if not token:
+                raise ValueError("Missing Apify token")
+            return {"api_token": token}
+        except Exception as e:
+            self.logger.error(f"Failed to authenticate Apify client: {e}")
+            return None
 
     def _init_tavily_client(self):
-        return None
+        try:
+            api_key = self.esc_manager.get_secret("research_tools.tavily_api_key")
+            if not api_key:
+                raise ValueError("Missing Tavily API key")
+            return {"api_key": api_key}
+        except Exception as e:
+            self.logger.error(f"Failed to authenticate Tavily client: {e}")
+            return None
 
     def _init_zenrows_client(self):
-        return None
+        try:
+            api_key = self.esc_manager.get_secret("research_tools.zenrows_api_key")
+            if not api_key:
+                raise ValueError("Missing ZenRows API key")
+            return {"api_key": api_key}
+        except Exception as e:
+            self.logger.error(f"Failed to authenticate ZenRows client: {e}")
+            return None
 
     def _init_twingly_client(self):
-        return None
+        try:
+            api_key = self.esc_manager.get_secret("research_tools.twingly_api_key")
+            if not api_key:
+                raise ValueError("Missing Twingly API key")
+            return {"api_key": api_key}
+        except Exception as e:
+            self.logger.error(f"Failed to authenticate Twingly client: {e}")
+            return None
 
     def _init_phantombuster_client(self):
-        return None
+        try:
+            api_key = self.esc_manager.get_secret("research_tools.phantombuster_api_key")
+            if not api_key:
+                raise ValueError("Missing PhantomBuster API key")
+            return {"api_key": api_key}
+        except Exception as e:
+            self.logger.error(f"Failed to authenticate PhantomBuster client: {e}")
+            return None
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_mcp_server_clients.py
+++ b/tests/unit/test_mcp_server_clients.py
@@ -1,0 +1,95 @@
+import importlib.util
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+
+import pytest
+
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "mcp-servers"))
+sys.path.insert(0, str(ROOT / "mcp-servers" / "snowflake"))
+from backend.integrations.pulumi_esc import SophiaESCManager
+
+# Dynamically load modules from the mcp-servers directory which uses a hyphen in the path
+sai_spec = importlib.util.spec_from_file_location(
+    "sai_mcp",
+    ROOT / "mcp-servers" / "sophia_ai_intelligence" / "sophia_ai_intelligence_mcp_server.py",
+)
+sai_mod = importlib.util.module_from_spec(sai_spec)
+sai_spec.loader.exec_module(sai_mod)
+
+sdi_spec = importlib.util.spec_from_file_location(
+    "sdi_mcp",
+    ROOT / "mcp-servers" / "sophia_data_intelligence" / "sophia_data_intelligence_mcp_server.py",
+)
+sdi_mod = importlib.util.module_from_spec(sdi_spec)
+sdi_spec.loader.exec_module(sdi_mod)
+
+si_spec = importlib.util.spec_from_file_location(
+    "si_mcp",
+    ROOT / "mcp-servers" / "sophia_infrastructure" / "sophia_infrastructure_mcp_server.py",
+)
+si_mod = importlib.util.module_from_spec(si_spec)
+si_spec.loader.exec_module(si_mod)
+
+SophiaAIIntelligenceMCPServer = sai_mod.SophiaAIIntelligenceMCPServer
+SophiaDataIntelligenceMCPServer = sdi_mod.SophiaDataIntelligenceMCPServer
+SophiaInfrastructureMCPServer = si_mod.SophiaInfrastructureMCPServer
+
+
+def _patch_secrets(monkeypatch, mapping):
+    def fake_get_secret(self, key):
+        return mapping.get(key)
+
+    monkeypatch.setattr(SophiaESCManager, "get_secret", fake_get_secret)
+
+
+def test_ai_intelligence_client_init(monkeypatch):
+    secrets = {
+        "observability.arize_api_key": "ARIZE",
+        "observability.arize_space_id": "SPACE",
+        "ai_services.openrouter_api_key": "OPEN",
+        "ai_services.portkey_api_key": "PORT",
+        "ai_services.portkey_config_id": "CFG",
+        "ai_services.huggingface_api_token": "HF",
+        "ai_services.togetherai_api_key": "TOG",
+    }
+    _patch_secrets(monkeypatch, secrets)
+    server = SophiaAIIntelligenceMCPServer()
+    assert server.arize_client == {"api_key": "ARIZE", "space_id": "SPACE"}
+    assert server.openrouter_client == {"api_key": "OPEN"}
+    assert server.portkey_client == {"api_key": "PORT", "config_id": "CFG"}
+    assert server.huggingface_client == {"api_token": "HF"}
+    assert server.together_client == {"api_key": "TOG"}
+
+
+def test_data_intelligence_client_init(monkeypatch):
+    secrets = {
+        "research_tools.apify_api_token": "APIFY",
+        "research_tools.tavily_api_key": "TAVILY",
+        "research_tools.zenrows_api_key": "ZEN",
+        "research_tools.twingly_api_key": "TWING",
+        "research_tools.phantombuster_api_key": "PHANTOM",
+    }
+    _patch_secrets(monkeypatch, secrets)
+    server = SophiaDataIntelligenceMCPServer()
+    assert server.apify_client == {"api_token": "APIFY"}
+    assert server.tavily_client == {"api_key": "TAVILY"}
+    assert server.zenrows_client == {"api_key": "ZEN"}
+    assert server.twingly_client == {"api_key": "TWING"}
+    assert server.phantombuster_client == {"api_key": "PHANTOM"}
+
+
+def test_infrastructure_client_init(monkeypatch):
+    secrets = {
+        "infrastructure.lambda_labs.api_key": "LAMBDA",
+        "infrastructure.pulumi.access_token": "PULUMI",
+        "infrastructure.docker.username": "DOCKERU",
+        "infrastructure.docker.token": "DOCKERT",
+    }
+    _patch_secrets(monkeypatch, secrets)
+    server = SophiaInfrastructureMCPServer()
+    assert server.lambda_client == {"api_key": "LAMBDA"}
+    assert server.pulumi_client == {"access_token": "PULUMI"}
+    assert server.docker_client == {"username": "DOCKERU", "token": "DOCKERT"}


### PR DESCRIPTION
## Summary
- wire up ESC manager in MCP servers
- add credential-based client init logic
- implement tests for client initialization

## Testing
- `pytest tests/unit/test_mcp_server_clients.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6856fda1f3f88328bd0eea904737cda8