### PR TITLE
Update docs for GitHub → ESC secrets workflow

### DIFF
--- a/docs/INTEGRATION_MANAGEMENT_GUIDE.md
+++ b/docs/INTEGRATION_MANAGEMENT_GUIDE.md
@@ -210,12 +210,11 @@ Secrets are managed using Pulumi ESC. This provides a secure way to manage sensi
 
 To add a new secret:
 
-1. Add the secret to the `.env` file
-2. Import the secret to Pulumi ESC:
+1. Add the secret to the **GitHub organization**.
+2. Synchronize secrets to Pulumi ESC:
 
 ```bash
-cd infrastructure
-./import_secrets.sh ../.env development
+./scripts/sync_github_to_pulumi.sh
 ```
 
 ### Rotating Secrets
@@ -223,13 +222,8 @@ cd infrastructure
 Secrets are rotated automatically every 90 days using GitHub Actions. To manually rotate a secret:
 
 1. Update the secret in the service (e.g., Snowflake, Gong, Vercel, Estuary)
-2. Update the secret in the `.env` file
-3. Import the secret to Pulumi ESC:
-
-```bash
-cd infrastructure
-./import_secrets.sh ../.env development
-```
+2. Update the secret in GitHub organization settings
+3. Run `./scripts/sync_github_to_pulumi.sh` to push the change to ESC
 
 ## Testing Integrations
 

--- a/docs/SECRETS_MANAGEMENT_IMPLEMENTATION.md
+++ b/docs/SECRETS_MANAGEMENT_IMPLEMENTATION.md
@@ -14,7 +14,6 @@ The SOPHIA AI System uses a multi-layered approach to secrets management:
 
 Organization secrets are managed using the `configure_github_org_secrets.py` script, which allows for:
 
-- Reading secrets from a `.env` file
 - Setting organization-level secrets with visibility controls
 - Listing existing secrets
 - Deleting specific or all secrets
@@ -22,8 +21,8 @@ Organization secrets are managed using the `configure_github_org_secrets.py` scr
 ### Usage
 
 ```bash
-# Set organization secrets from a .env file
-python configure_github_org_secrets.py --env-file .env.secure --org ai-cherry
+# Set organization secrets using the provided script
+python configure_github_org_secrets.py --org ai-cherry
 
 # List existing secrets
 python configure_github_org_secrets.py --org ai-cherry --list
@@ -45,20 +44,16 @@ Organization secrets can have different visibility settings:
 
 ## GitHub Repository Secrets
 
-Repository secrets are managed using the `import_secrets_to_github.py` script, which allows for:
-
-- Reading secrets from a `.env` file
-- Setting repository-level secrets
-- Dry-run mode for testing
+Repository secrets are managed using the `import_secrets_to_github.py` script, which allows for setting repository-level secrets and supports a dry-run mode for testing.
 
 ### Usage
 
 ```bash
-# Set repository secrets from a .env file
-python import_secrets_to_github.py --env-file .env.secure --repo ai-cherry/sophia
+# Set repository secrets
+python import_secrets_to_github.py --repo ai-cherry/sophia
 
 # Test without making changes
-python import_secrets_to_github.py --env-file .env.secure --repo ai-cherry/sophia --dry-run
+python import_secrets_to_github.py --repo ai-cherry/sophia --dry-run
 ```
 
 ## Pulumi ESC Integration
@@ -86,11 +81,8 @@ Access policies define who can access which secrets in which environments:
 ### Usage
 
 ```bash
-# Import secrets from a .env file
-./configure_pulumi_esc.sh import-env .env.secure
-
-# Sync secrets to GitHub Actions
-./configure_pulumi_esc.sh sync
+# Sync secrets from GitHub to ESC
+./scripts/sync_github_to_pulumi.sh
 
 # List all secrets (values are masked)
 ./configure_pulumi_esc.sh list
@@ -112,11 +104,11 @@ The `configure_github_org_secrets.py` script uses the GitHub API through the PyG
 
 ### GitHub Repository Secrets
 
-The `import_secrets_to_github.py` script uses the GitHub CLI to set repository secrets. It reads secrets from a `.env` file and sets them one by one.
+The `import_secrets_to_github.py` script uses the GitHub CLI to set repository secrets based on key/value pairs provided at runtime or via environment variables.
 
 ### Pulumi ESC
 
-The `configure_pulumi_esc.sh` script uses the Pulumi CLI to manage secrets in Pulumi ESC. It can import secrets from a `.env` file, sync them to GitHub Actions, and list all secrets.
+The `configure_pulumi_esc.sh` script uses the Pulumi CLI to manage secrets in Pulumi ESC. It can synchronize secrets with GitHub Actions and list existing values.
 
 ## Next Steps
 

--- a/docs/SECRET_MANAGEMENT_GUIDE.md
+++ b/docs/SECRET_MANAGEMENT_GUIDE.md
@@ -217,8 +217,8 @@ Use the `configure_github_secrets.py` script to set up GitHub secrets:
 # Install required packages
 pip install PyGithub pynacl
 
-# Configure secrets from .env file
-python configure_github_secrets.py --env-file .env --repo payready/sophia
+# Configure secrets directly
+python configure_github_secrets.py --repo payready/sophia
 ```
 
 ### GitHub Actions Usage
@@ -254,14 +254,8 @@ Secrets should be rotated regularly according to the following schedule:
 ### Rotation Procedure
 
 1. Generate new credentials in the external service
-2. Update the secret in Pulumi ESC:
-   ```bash
-   ./configure_pulumi_esc.sh import-env .env.new
-   ```
-3. Sync the secret to GitHub:
-   ```bash
-   ./configure_pulumi_esc.sh sync
-   ```
+2. Update the secret in GitHub organization settings
+3. Run `./scripts/sync_github_to_pulumi.sh` to update ESC
 4. Deploy the application with the new secrets
 5. Verify functionality with the new secrets
 6. Revoke the old credentials in the external service
@@ -275,11 +269,9 @@ The secrets management system includes the following tools:
 A comprehensive script for managing secrets and environment variables. It can:
 
 - Detect missing environment variables
-- Import secrets from various sources (.env files, Pulumi ESC, GitHub)
-- Export secrets to various destinations (.env files, Pulumi ESC, GitHub)
+- Sync secrets between GitHub and Pulumi ESC
 - Validate secret configurations
-- Generate template .env files
-- Sync secrets across different environments
+- Generate template files when needed
 
 ### 2. `setup_new_repo.py`
 
@@ -288,7 +280,7 @@ A script to automate the setup of a new Sophia AI repository with all the necess
 - Creates a new directory for the repository
 - Initializes a Git repository
 - Copies the secrets_manager.py script
-- Imports secrets from a master .env file or Pulumi ESC
+- Pulls secrets from Pulumi ESC
 - Sets up the necessary configuration files
 - Creates a README.md file with setup instructions
 
@@ -409,10 +401,7 @@ To set up a new repository with all the necessary secrets and configurations:
 # Create a new repository with a specific name
 ./setup_new_repo.py --name sophia-new-repo
 
-# Create a new repository and import secrets from a master .env file
-./setup_new_repo.py --name sophia-new-repo --source-env /path/to/master.env
-
-# Create a new repository and import secrets from Pulumi ESC
+# Create a new repository and pull secrets from Pulumi ESC
 ./setup_new_repo.py --name sophia-new-repo --from-pulumi
 ```
 
@@ -426,21 +415,10 @@ To set up a new repository with all the necessary secrets and configurations:
 
 This command will check for missing required environment variables and display them with their descriptions.
 
-#### Importing Secrets from a .env File
+#### Importing and Exporting Secrets
 
-```bash
-./secrets_manager.py import-from-env --env-file .env
-```
-
-This command will import environment variables from a .env file and add them to the current environment.
-
-#### Exporting Secrets to a .env File
-
-```bash
-./secrets_manager.py export-to-env --env-file .env.new
-```
-
-This command will export the current environment variables to a .env file, organized by category.
+The `secrets_manager.py` utility can import or export secrets between GitHub and
+Pulumi ESC. Local `.env` files are no longer required.
 
 #### Syncing Secrets to Pulumi ESC
 
@@ -480,7 +458,7 @@ This command will generate a template .env file with all required and optional v
 ./secrets_manager.py sync-all
 ```
 
-This command will sync all secrets to all destinations: .env file, Pulumi ESC, and GitHub Secrets.
+This command will sync all secrets between GitHub and Pulumi ESC.
 
 ## Best Practices
 

--- a/docs/github_workflow.md
+++ b/docs/github_workflow.md
@@ -123,6 +123,10 @@ If you encounter issues with the workflow, check the following:
 4. **Logs**: Check the workflow logs for error messages:
    - Look for errors in the "setup-pulumi-esc" job
    - Look for errors in the secret retrieval and injection steps
+5. **ESC Sync Failures**:
+   - Run `./scripts/sync_github_to_pulumi.sh` locally to force a sync
+   - Verify the "unified-secret-sync" workflow completed successfully
+   - Ensure the ESC environment exists with `pulumi env ls`
 
 ## Adding a New Service
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -33,15 +33,15 @@ This will create three stacks:
 - `staging`
 - `production`
 
-### 2. Import Secrets
+### 2. Sync Secrets from GitHub
 
-Import secrets from a `.env` file to Pulumi ESC:
+All secrets are stored as GitHub organization secrets and automatically
+synchronized to Pulumi ESC via GitHub Actions. If you need to trigger a manual
+sync run:
 
 ```bash
-./import_secrets.sh ../.env development
+../scripts/sync_github_to_pulumi.sh
 ```
-
-Replace `development` with the appropriate stack name (`staging` or `production`).
 
 ### 3. Deploy Infrastructure
 
@@ -62,7 +62,7 @@ pulumi up
 - `Pulumi.yaml`: Pulumi project configuration
 - `requirements.txt`: Python dependencies
 - `init_stacks.sh`: Script to initialize Pulumi stacks
-- `import_secrets.sh`: Script to import secrets from a `.env` file to Pulumi ESC
+- `sync_github_to_pulumi.sh`: Manually triggers a GitHub → ESC secret sync
 
 ## Environment-Specific Configuration
 
@@ -82,6 +82,13 @@ pulumi config set --secret <key> <value>
 ## Secret Management
 
 Secrets are managed using Pulumi ESC (Environments, Secrets, and Configuration). This provides a secure way to manage sensitive information across different environments.
+
+### GitHub → Pulumi ESC Workflow
+
+GitHub organization secrets are the source of truth for all infrastructure
+credentials. A GitHub Actions workflow automatically synchronizes these secrets
+to the ESC environment referenced by this project. Manual syncs can be run with
+`../scripts/sync_github_to_pulumi.sh` if needed.
 
 To view the current configuration:
 
@@ -117,6 +124,20 @@ For more detailed information, use the `--verbose` flag:
 ```bash
 pulumi up --verbose
 ```
+
+### ESC Sync Failures
+
+If secrets fail to appear in Pulumi ESC:
+
+1. Verify `GH_TOKEN` and `PULUMI_ACCESS_TOKEN` are configured in GitHub
+   organization secrets.
+2. Re-run the sync script:
+
+   ```bash
+   ../scripts/sync_github_to_pulumi.sh
+   ```
+3. Check the "unified-secret-sync" workflow logs in GitHub Actions for errors.
+4. Ensure the target ESC environment exists with `pulumi env ls`.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- remove `.env` import instructions from infrastructure README and related docs
- document GitHub → Pulumi ESC sync workflow
- add troubleshooting steps for ESC sync failures

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pulumi.automation')*

------
https://chatgpt.com/codex/tasks/task_e_6856fd9f2524832892de8967c719f0f2