### PR TITLE
Add Pulumi automation API module

### DIFF
--- a/infrastructure/sophia_automation_api.py
+++ b/infrastructure/sophia_automation_api.py
@@ -1,0 +1,96 @@
+"""Automation utilities for managing Sophia AI infrastructure with Pulumi.
+
+This module provides high-level functions for programmatic stack creation,
+scaling, and cost optimisation. It integrates with the Pulumi ESC environment
+configuration via :class:`~infrastructure.pulumi_esc.PulumiESCManager`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, Optional
+
+from pulumi import automation as auto
+
+from .pulumi_esc import PulumiESCManager
+
+logger = logging.getLogger(__name__)
+
+
+async def create_stack(
+    stack_name: str,
+    program: Callable[[], None],
+    *,
+    config: Optional[Dict[str, Any]] = None,
+    preview: bool = False,
+) -> auto.UpResult | auto.PreviewResult:
+    """Create or select a Pulumi stack and optionally deploy it.
+
+    The stack will automatically be configured with values fetched from Pulumi
+    ESC if available. Additional configuration can be supplied via ``config``.
+
+    Args:
+        stack_name: Name of the stack to create or select.
+        program: Pulumi program to run.
+        config: Additional configuration values.
+        preview: If ``True`` run ``preview`` instead of ``up``.
+
+    Returns:
+        The result of ``stack.up()`` or ``stack.preview()``.
+    """
+    logger.info("Creating stack '%s'", stack_name)
+
+    esc = PulumiESCManager()
+    await esc.initialize()
+
+    stack = auto.create_or_select_stack(
+        stack_name=stack_name, project_name="sophia-iac", program=program
+    )
+
+    env = (
+        await esc.get_secret("PULUMI_ENVIRONMENT")
+        or (config or {}).get("environment")
+        or "development"
+    )
+    await stack.set_config("environment", auto.ConfigValue(value=env))
+
+    if config:
+        for key, value in config.items():
+            await stack.set_config(key, auto.ConfigValue(value=str(value)))
+
+    if preview:
+        logger.info("Previewing stack '%s'", stack_name)
+        return await stack.preview(on_output=logger.debug)
+
+    logger.info("Deploying stack '%s'", stack_name)
+    return await stack.up(on_output=logger.debug)
+
+
+async def scale_stack(stack_name: str, *, replicas: int) -> auto.UpResult:
+    """Dynamically scale stack resources.
+
+    The implementation assumes the stack respects a ``replicas`` configuration
+    value. This value is updated and the stack is deployed.
+    """
+    logger.info("Scaling stack '%s' to %s replicas", stack_name, replicas)
+
+    stack = auto.select_stack(
+        stack_name=stack_name, project_name="sophia-iac", program=lambda: None
+    )
+    await stack.set_config("replicas", auto.ConfigValue(value=str(replicas)))
+    return await stack.up(on_output=logger.debug)
+
+
+async def optimize_costs(stack_name: str) -> auto.UpResult:
+    """Apply cost optimisation settings to the stack and deploy.
+
+    This sets a ``cost_optimization`` flag in stack configuration which can be
+    consumed by the Pulumi program to adjust resources.
+    """
+    logger.info("Enabling cost optimisation for stack '%s'", stack_name)
+
+    stack = auto.select_stack(
+        stack_name=stack_name, project_name="sophia-iac", program=lambda: None
+    )
+    await stack.set_config("cost_optimization", auto.ConfigValue(value="true"))
+    return await stack.up(on_output=logger.debug)

--- a/tests/infrastructure/integration/test_sophia_automation_api.py
+++ b/tests/infrastructure/integration/test_sophia_automation_api.py
@@ -1,0 +1,37 @@
+"""Integration tests for the Sophia automation API."""
+
+import os
+import shutil
+import sys
+import uuid
+
+import pytest
+
+# Add project root to import path
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../"))
+)
+
+from infrastructure.sophia_automation_api import create_stack
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_create_stack_preview(test_env_manager):
+    """Ensure a stack can be created in preview mode without deploying resources."""
+    stack_name = f"preview-{uuid.uuid4().hex[:8]}"
+
+    def program():
+        # empty Pulumi program for preview
+        pass
+
+    if shutil.which("pulumi") is None:
+        pytest.skip("Pulumi CLI not installed")
+
+    os.environ.setdefault("PULUMI_ACCESS_TOKEN", "test-token")
+
+    result = await create_stack(stack_name, program, preview=True)
+
+    assert hasattr(result, "change_summary")
+
+    test_env_manager.cleanup_test_stack(stack_name)


### PR DESCRIPTION
## Summary
- add `sophia_automation_api` with helper functions for Pulumi stack automation
- integrate ESC manager and provide scaling and cost optimisation helpers
- ensure package initialization for infrastructure modules
- add integration test for automation API stack preview

## Testing
- `pre-commit run --files infrastructure/sophia_automation_api.py tests/infrastructure/integration/test_sophia_automation_api.py infrastructure/__init__.py`
- `pytest tests/infrastructure/integration/test_sophia_automation_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6856fd9d504083288c7f99ee07461ea0