### PR TITLE
Update Cursor configs for MCP

### DIFF
--- a/.cursor-settings.json
+++ b/.cursor-settings.json
@@ -6,6 +6,12 @@
   "pulumi.ai.naturalLanguage": true,
   "typescript.preferences.includePackageJsonAutoImports": "on",
   "typescript.suggest.autoImports": true,
+  "mcpServers": {
+    "sophia_ai_intelligence": {"url": "http://localhost:8101"},
+    "sophia_data_intelligence": {"url": "http://localhost:8102"},
+    "sophia_infrastructure": {"url": "http://localhost:8103"},
+    "sophia_business_intelligence": {"url": "http://localhost:8104"}
+  },
   "pulumi.ai.customPrompts": {
     "dashboard": "Generate Pulumi infrastructure for Sophia AI dashboard with Gong, Snowflake, and OpenAI integrations",
     "security": "Apply enterprise security policies for financial services compliance",
@@ -31,6 +37,27 @@
       "prompt": "Optimize Sophia AI infrastructure for cost and performance:",
       "context": ["infrastructure/", "monitoring/"],
       "postAction": "pulumi:analyze-costs"
+    },
+    "scale-infrastructure": {
+      "prompt": "Scale Sophia AI infrastructure to handle increased demand:",
+      "context": ["infrastructure/"],
+      "postAction": "pulumi:scale-infra"
+    },
+    "cost-optimization": {
+      "prompt": "Identify cost saving opportunities across Sophia AI platform:",
+      "context": ["infrastructure/", "monitoring/"]
+    },
+    "lead-generation": {
+      "prompt": "Generate new sales leads from Sophia data sources:",
+      "context": ["backend/integrations/", "mcp-servers/"]
+    },
+    "performance-analysis": {
+      "prompt": "Analyze performance metrics for Sophia AI services:",
+      "context": ["monitoring/", "backend/"]
+    },
+    "deploy-pinecone-index": {
+      "prompt": "Deploy a Pinecone index for vector search:",
+      "context": ["infrastructure/", "backend/vector/"]
     }
   }
 }

--- a/.cursor/mcp_settings.json
+++ b/.cursor/mcp_settings.json
@@ -5,13 +5,13 @@
       "args": ["-m", "mcp-servers.sophia_ai_intelligence.sophia_ai_intelligence_mcp_server"],
       "cwd": "/home/ubuntu/sophia-main",
       "env": {
-        "ARIZE_SPACE_ID": "${ESC_ARIZE_SPACE_ID}",
-        "ARIZE_API_KEY": "${ESC_ARIZE_API_KEY}",
-        "OPENROUTER_API_KEY": "${ESC_OPENROUTER_API_KEY}",
-        "PORTKEY_API_KEY": "${ESC_PORTKEY_API_KEY}",
-        "PORTKEY_CONFIG": "${ESC_PORTKEY_CONFIG}",
-        "HUGGINGFACE_API_TOKEN": "${ESC_HUGGINGFACE_API_TOKEN}",
-        "TOGETHER_AI_API_KEY": "${ESC_TOGETHER_AI_API_KEY}"
+        "ARIZE_SPACE_ID": "${config:ARIZE_SPACE_ID}",
+        "ARIZE_API_KEY": "${config:ARIZE_API_KEY}",
+        "OPENROUTER_API_KEY": "${config:OPENROUTER_API_KEY}",
+        "PORTKEY_API_KEY": "${config:PORTKEY_API_KEY}",
+        "PORTKEY_CONFIG": "${config:PORTKEY_CONFIG}",
+        "HUGGINGFACE_API_TOKEN": "${config:HUGGINGFACE_API_TOKEN}",
+        "TOGETHER_AI_API_KEY": "${config:TOGETHER_AI_API_KEY}"
       }
     },
     "sophia_data_intelligence": {
@@ -19,11 +19,11 @@
       "args": ["-m", "mcp-servers.sophia_data_intelligence.sophia_data_intelligence_mcp_server"],
       "cwd": "/home/ubuntu/sophia-main",
       "env": {
-        "APIFY_API_TOKEN": "${ESC_APIFY_API_TOKEN}",
-        "PHANTOM_BUSTER_API_KEY": "${ESC_PHANTOM_BUSTER_API_KEY}",
-        "TWINGLY_API_KEY": "${ESC_TWINGLY_API_KEY}",
-        "TAVILY_API_KEY": "${ESC_TAVILY_API_KEY}",
-        "ZENROWS_API_KEY": "${ESC_ZENROWS_API_KEY}"
+        "APIFY_API_TOKEN": "${config:APIFY_API_TOKEN}",
+        "PHANTOM_BUSTER_API_KEY": "${config:PHANTOM_BUSTER_API_KEY}",
+        "TWINGLY_API_KEY": "${config:TWINGLY_API_KEY}",
+        "TAVILY_API_KEY": "${config:TAVILY_API_KEY}",
+        "ZENROWS_API_KEY": "${config:ZENROWS_API_KEY}"
       }
     },
     "sophia_infrastructure": {
@@ -31,10 +31,10 @@
       "args": ["-m", "mcp-servers.sophia_infrastructure.sophia_infrastructure_mcp_server"],
       "cwd": "/home/ubuntu/sophia-main",
       "env": {
-        "LAMBDA_LABS_API_KEY": "${ESC_LAMBDA_LABS_API_KEY}",
-        "PULUMI_ACCESS_TOKEN": "${ESC_PULUMI_ACCESS_TOKEN}",
-        "DOCKER_USERNAME": "${ESC_DOCKER_USER_NAME}",
-        "DOCKER_TOKEN": "${ESC_DOCKER_TOKEN}"
+        "LAMBDA_LABS_API_KEY": "${config:LAMBDA_LABS_API_KEY}",
+        "PULUMI_ACCESS_TOKEN": "${config:PULUMI_ACCESS_TOKEN}",
+        "DOCKER_USERNAME": "${config:DOCKER_USER_NAME}",
+        "DOCKER_TOKEN": "${config:DOCKER_TOKEN}"
       }
     },
     "sophia_business_intelligence": {
@@ -42,13 +42,13 @@
       "args": ["-m", "mcp-servers.snowflake.snowflake_mcp_server"],
       "cwd": "/home/ubuntu/sophia-main",
       "env": {
-        "SNOWFLAKE_ACCOUNT": "${ESC_SNOWFLAKE_ACCOUNT}",
-        "SNOWFLAKE_USER": "${ESC_SNOWFLAKE_USER}",
-        "SNOWFLAKE_PASSWORD": "${ESC_SNOWFLAKE_PASSWORD}",
-        "SNOWFLAKE_WAREHOUSE": "${ESC_SNOWFLAKE_WAREHOUSE}",
-        "SNOWFLAKE_DATABASE": "${ESC_SNOWFLAKE_DATABASE}",
-        "SNOWFLAKE_SCHEMA": "${ESC_SNOWFLAKE_SCHEMA}",
-        "PINECONE_API_KEY": "${ESC_PINECONE_API_KEY}"
+        "SNOWFLAKE_ACCOUNT": "${config:SNOWFLAKE_ACCOUNT}",
+        "SNOWFLAKE_USER": "${config:SNOWFLAKE_USER}",
+        "SNOWFLAKE_PASSWORD": "${config:SNOWFLAKE_PASSWORD}",
+        "SNOWFLAKE_WAREHOUSE": "${config:SNOWFLAKE_WAREHOUSE}",
+        "SNOWFLAKE_DATABASE": "${config:SNOWFLAKE_DATABASE}",
+        "SNOWFLAKE_SCHEMA": "${config:SNOWFLAKE_SCHEMA}",
+        "PINECONE_API_KEY": "${config:PINECONE_API_KEY}"
       }
     }
   }

--- a/.cursor/sophia_ai_mcp_config.json
+++ b/.cursor/sophia_ai_mcp_config.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "sophia_ai_intelligence": {"url": "http://localhost:8101"},
+    "sophia_data_intelligence": {"url": "http://localhost:8102"},
+    "sophia_infrastructure": {"url": "http://localhost:8103"},
+    "sophia_business_intelligence": {"url": "http://localhost:8104"}
+  }
+}


### PR DESCRIPTION
## Summary
- reference ESC secrets via `config` helper
- add MCP server endpoints for Cursor
- extend Cursor custom commands with infrastructure, lead generation and Pinecone commands

## Testing
- `pre-commit run --files .cursor/mcp_settings.json .cursor/sophia_ai_mcp_config.json .cursor-settings.json`

------
https://chatgpt.com/codex/tasks/task_e_6856fd99614c8328b46cdd6953f4264a