### PR TITLE
Add Sophia containerization deployments

### DIFF
--- a/infrastructure/sophia_containerization.py
+++ b/infrastructure/sophia_containerization.py
@@ -1,0 +1,133 @@
+from typing import Dict, List, Optional
+
+import yaml
+
+# Configuration for each service
+SERVICE_CONFIGS = {
+    "ai-service": {
+        "image": "ghcr.io/sophia/ai:latest",
+        "replicas": 2,
+        "cpu": "2",
+        "memory": "2Gi",
+        "gpu": 1,
+    },
+    "data-service": {
+        "image": "ghcr.io/sophia/data:latest",
+        "replicas": 1,
+        "cpu": "1",
+        "memory": "1Gi",
+        "gpu": 0,
+    },
+    "bi-service": {
+        "image": "ghcr.io/sophia/bi:latest",
+        "replicas": 1,
+        "cpu": "1",
+        "memory": "1Gi",
+        "gpu": 0,
+    },
+    "infra-service": {
+        "image": "ghcr.io/sophia/infra:latest",
+        "replicas": 1,
+        "cpu": "500m",
+        "memory": "512Mi",
+        "gpu": 0,
+    },
+}
+
+
+def _create_deployment(
+    name: str,
+    image: str,
+    replicas: int,
+    cpu: str,
+    memory: str,
+    gpu: int = 0,
+) -> Dict:
+    """Create a Kubernetes Deployment manifest."""
+    resources = {
+        "requests": {"cpu": cpu, "memory": memory},
+        "limits": {"cpu": cpu, "memory": memory},
+    }
+    node_selector: Optional[Dict[str, str]] = None
+    tolerations: Optional[List[Dict[str, str]]] = None
+
+    if gpu:
+        resources["requests"]["nvidia.com/gpu"] = str(gpu)
+        resources["limits"]["nvidia.com/gpu"] = str(gpu)
+        node_selector = {"lambda.labs/gpu": "true"}
+        tolerations = [
+            {
+                "key": "nvidia.com/gpu",
+                "operator": "Exists",
+                "effect": "NoSchedule",
+            }
+        ]
+
+    container = {
+        "name": name,
+        "image": image,
+        "resources": resources,
+        "livenessProbe": {
+            "httpGet": {"path": "/healthz", "port": 80},
+            "initialDelaySeconds": 10,
+            "periodSeconds": 10,
+        },
+        "readinessProbe": {
+            "httpGet": {"path": "/ready", "port": 80},
+            "initialDelaySeconds": 5,
+            "periodSeconds": 10,
+        },
+    }
+
+    pod_spec = {
+        "containers": [container],
+    }
+    if node_selector:
+        pod_spec["nodeSelector"] = node_selector
+    if tolerations:
+        pod_spec["tolerations"] = tolerations
+
+    deployment = {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {"name": name, "namespace": "sophia"},
+        "spec": {
+            "replicas": replicas,
+            "selector": {"matchLabels": {"app": name}},
+            "strategy": {
+                "type": "RollingUpdate",
+                "rollingUpdate": {"maxSurge": "25%", "maxUnavailable": "25%"},
+            },
+            "template": {
+                "metadata": {"labels": {"app": name}},
+                "spec": pod_spec,
+            },
+        },
+    }
+    return deployment
+
+
+def generate_deployments() -> List[Dict]:
+    """Generate manifests for all Sophia services."""
+    manifests = []
+    for name, cfg in SERVICE_CONFIGS.items():
+        manifests.append(
+            _create_deployment(
+                name=name,
+                image=cfg["image"],
+                replicas=cfg["replicas"],
+                cpu=cfg["cpu"],
+                memory=cfg["memory"],
+                gpu=cfg["gpu"],
+            )
+        )
+    return manifests
+
+
+def generate_yaml() -> str:
+    """Return the Kubernetes manifests as a YAML string."""
+    return yaml.safe_dump_all(generate_deployments())
+
+
+if __name__ == "__main__":
+    print(generate_yaml())

--- a/tests/infrastructure/integration/test_sophia_containerization.py
+++ b/tests/infrastructure/integration/test_sophia_containerization.py
@@ -1,0 +1,46 @@
+import os
+import sys
+
+import pytest
+import yaml
+
+# Add project root to path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../")))
+from infrastructure.sophia_containerization import generate_deployments, generate_yaml
+
+
+@pytest.mark.integration
+class TestSophiaContainerization:
+    def test_manifest_generation(self):
+        manifests = generate_deployments()
+        assert len(manifests) == 4
+        names = {m["metadata"]["name"] for m in manifests}
+        assert names == {"ai-service", "data-service", "bi-service", "infra-service"}
+
+        for m in manifests:
+            spec = m["spec"]
+            template = spec["template"]
+            pod = template["spec"]
+            container = pod["containers"][0]
+
+            # check resources
+            assert "resources" in container
+            assert "requests" in container["resources"]
+            assert "limits" in container["resources"]
+            assert "cpu" in container["resources"]["requests"]
+            assert "memory" in container["resources"]["requests"]
+
+            # check health probes
+            assert "livenessProbe" in container
+            assert "readinessProbe" in container
+
+            # check rolling update strategy
+            strategy = spec.get("strategy", {})
+            assert strategy.get("type") == "RollingUpdate"
+            assert "rollingUpdate" in strategy
+
+    def test_yaml_output(self):
+        text = generate_yaml()
+        docs = list(yaml.safe_load_all(text))
+        assert len(docs) == 4
+        assert isinstance(docs[0], dict)


### PR DESCRIPTION
## Summary
- define Kubernetes deployments for AI, Data, BI and Infrastructure services
- add integration tests for the generated manifests

## Testing
- `ruff check infrastructure/sophia_containerization.py tests/infrastructure/integration/test_sophia_containerization.py`
- `pytest tests/infrastructure/integration/test_sophia_containerization.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6856fd9be3cc8328a43e6b5e48886d8e