### PR TITLE
Fix Anthropic API key placeholder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ POSTGRES_PASSWORD=your_postgres_password_here
 POSTGRES_DB=sophia_enhanced
 
 # AI Services
-ANTHROPIC_API_KEY=sk-ant-api03-your_anthropic_key_here
+ANTHROPIC_API_KEY=your_anthropic_key_here
 OPENAI_API_KEY=sk-your_openai_key_here
 
 # Business Integrations


### PR DESCRIPTION
## Summary
- keep `.env.example` neutral by removing the `sk-ant-api03` prefix from `ANTHROPIC_API_KEY`

## Testing
- `pre-commit run --files .env.example`
- `pytest -q` *(fails: ModuleNotFoundError and SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_6857be871ff483289254d33a2e264cc2