### PR TITLE
Update Anthropic API key regex

### DIFF
--- a/backend/core/secure_environment_validator.py
+++ b/backend/core/secure_environment_validator.py
@@ -97,7 +97,8 @@ class SecureEnvironmentValidator:
                 name="ANTHROPIC_API_KEY",
                 required=False,
                 secret_type=SecretType.API_KEY,
-                pattern=r"^sk-ant-api03-[a-zA-Z0-9_-]{95}$",
+                # Accept generic Anthropic API key pattern without hardcoded prefix
+                pattern=r"^sk-[a-zA-Z0-9_-]{95}$",
                 description="Anthropic Claude API key",
             ),
             # Vector Databases


### PR DESCRIPTION
## Summary
- relax regex for `ANTHROPIC_API_KEY` so it accepts generic keys without the `api03` prefix

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_6857be865cd88328ae345f08de2d9da1