### PR TITLE
Fix logging call

### DIFF
--- a/scripts/ingest_codebase.py
+++ b/scripts/ingest_codebase.py
@@ -59,7 +59,8 @@ class RepositoryIntelligenceService:
         )
 
     def scan_repository(self) -> List[Path]:
-        """Scans the repository for relevant files to ingest."""logging.info("Scanning repository for relevant files...").
+        """Scans the repository for relevant files to ingest."""
+        logging.info("Scanning repository for relevant files...")
 
         relevant_files = []
         for path in self.root_path.rglob("*"):


### PR DESCRIPTION
## Summary
- split docstring from logging call in `ingest_codebase.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and SyntaxError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6857be82c8f883289f5c30a3bffade18