### PR TITLE
Improve ESC config loader and add registry tools

### DIFF
--- a/backend/core/auto_esc_config.py
+++ b/backend/core/auto_esc_config.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import subprocess
 from typing import Any, Optional
 
 from pydantic import BaseModel, ValidationError
+
+logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
 
 
 class Settings(BaseModel):
@@ -15,6 +18,9 @@ class Settings(BaseModel):
 
     openai_api_key: Optional[str] = None
     snowflake_account: Optional[str] = None
+    snowflake_user: Optional[str] = None
+    snowflake_password: Optional[str] = None
+    slack_bot_token: Optional[str] = None
 
 
 class AutoESCConfig:
@@ -44,13 +50,22 @@ class AutoESCConfig:
             "--format",
             "json",
         ]
+        logging.debug("Loading ESC config via: %s", " ".join(cmd))
         try:
             result = subprocess.run(cmd, capture_output=True, text=True, check=False)
-            if result.returncode == 0:
-                self._config = json.loads(result.stdout)
-            else:
+            if result.returncode != 0:
+                logging.error("pulumi env open failed: %s", result.stderr.strip())
                 self._config = {}
-        except Exception:
+                return
+            self._config = json.loads(result.stdout)
+            logging.info(
+                "Loaded ESC configuration with %d keys", len(self._config or {})
+            )
+        except json.JSONDecodeError as exc:
+            logging.exception("Failed to parse ESC output: %s", exc)
+            self._config = {}
+        except Exception as exc:  # pragma: no cover - defensive
+            logging.exception("Unexpected error loading ESC config: %s", exc)
             self._config = {}
 
     def get(self, key: str, default: Any | None = None) -> Any | None:
@@ -65,7 +80,7 @@ class AutoESCConfig:
 
         try:
             return Settings(**(self._config or {}))
-        except ValidationError as exc:
+        except ValidationError as exc:  # pragma: no cover - defensive
             raise RuntimeError(f"Invalid ESC configuration: {exc}") from exc
 
 

--- a/infrastructure/migrate_service_registry.py
+++ b/infrastructure/migrate_service_registry.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Merge integration_registry.json and service_registry.json into services_registry.json."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def load(path: Path) -> Dict[str, Any]:
+    """Load JSON data from ``path`` if it exists."""
+    if not path.exists():
+        return {}
+    with path.open() as f:
+        return json.load(f)
+
+
+def merge_dicts(primary: Dict[str, Any], secondary: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge two service registries."""
+    result: Dict[str, Any] = {}
+    keys = set(primary) | set(secondary)
+    for key in sorted(keys):
+        a = primary.get(key, {})
+        b = secondary.get(key, {})
+        merged = {**a, **b}
+        for list_key in ["config_keys", "secret_keys", "dependencies", "features"]:
+            if list_key in a or list_key in b:
+                merged[list_key] = sorted(
+                    set(a.get(list_key, []) + b.get(list_key, []))
+                )
+        result[key] = merged
+    return result
+
+
+def main() -> None:
+    integration_file = Path("integration_registry.json")
+    service_file = Path("service_registry.json")
+    unified_file = Path("services_registry.json")
+
+    integration = load(integration_file)
+    service = load(service_file)
+    unified = merge_dicts(integration, service)
+
+    with unified_file.open("w") as f:
+        json.dump(unified, f, indent=2)
+    print(f"Wrote {len(unified)} services to {unified_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/infrastructure/run_all_tests.py
+++ b/tests/infrastructure/run_all_tests.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Convenience script to run infrastructure tests."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run infrastructure tests")
+    parser.add_argument("--quick", action="store_true", help="Run unit tests only")
+    args = parser.parse_args()
+
+    test_dir = Path(__file__).resolve().parent
+    if args.quick:
+        target = test_dir / "unit"
+    else:
+        target = test_dir
+
+    cmd = ["pytest", str(target)]
+    subprocess.run(cmd, check=False)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- improve `AutoESCConfig` with logging and better typing
- add `migrate_service_registry.py` utility to merge registries
- add convenience script for running infrastructure tests

## Testing
- `pytest -q`
- `pre-commit run --files backend/core/auto_esc_config.py infrastructure/migrate_service_registry.py tests/infrastructure/run_all_tests.py` *(fails: bandit missing config, python-syntax-validator missing)*

------
https://chatgpt.com/codex/tasks/task_e_68589b7b9bbc8328a865269b4a39a391