### PR TITLE
Remove agno from simplified requirements

### DIFF
--- a/requirements_simplified.txt
+++ b/requirements_simplified.txt
@@ -19,9 +19,6 @@ httpx==0.27.2
 openai==1.90.0
 anthropic==0.34.2
 
-# Agno Framework
-agno[all]
-
 # Monitoring
 prometheus-client
 psutil


### PR DESCRIPTION
## Summary
- remove `agno[all]` from requirements_simplified.txt

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68589f79f994832896bdca7eb2ef2174