### PR TITLE
Comment out agno-mcp service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -265,17 +265,17 @@ services:
         MCP_SERVER_MODULE: backend.mcp.docker_mcp_server
     container_name: sophia-docker-mcp
 
-  agno-mcp:
-    <<: *base-mcp-service
-    build:
-      args:
-        MCP_SERVER_MODULE: backend.mcp.agno_mcp_server
-    container_name: sophia-agno-mcp
-    environment:
-      - AGNO_API_KEY=${AGNO_API_KEY}
-      - PYTHONUNBUFFERED=1
-      - PULUMI_ORG=${PULUMI_ORG}
-
+#   agno-mcp:
+#     <<: *base-mcp-service
+#     build:
+#       args:
+#         MCP_SERVER_MODULE: backend.mcp.agno_mcp_server
+#     container_name: sophia-agno-mcp
+#     environment:
+#       - AGNO_API_KEY=${AGNO_API_KEY}
+#       - PYTHONUNBUFFERED=1
+#       - PULUMI_ORG=${PULUMI_ORG}
+#
   pulumi-mcp:
     <<: *base-mcp-service
     build:


### PR DESCRIPTION
## Summary
- comment out the `agno-mcp` service in `docker-compose.yml`

## Testing
- `pre-commit run --files docker-compose.yml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx' and 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68589f7b44888328bc0f00a98b1dcc9d