### PR TITLE
Fix new_version assignment in Snowflake config schema

### DIFF
--- a/backend/snowflake_setup/config_schema.sql
+++ b/backend/snowflake_setup/config_schema.sql
@@ -474,7 +474,7 @@ BEGIN
     END IF;
     
     -- Calculate new version
-    SET new_version = old_version + 1;
+    new_version := old_version + 1;
     
     -- Update the setting
     UPDATE APPLICATION_SETTINGS


### PR DESCRIPTION
## Summary
- use Snowflake Scripting assignment syntax for `new_version`
- attempted to compile stored procedure using Snowflake connector

## Testing
- `pytest -q`
- `pip install snowflake-connector-python`
- `python - <<'PY' ...` (attempt to connect to Snowflake)

------
https://chatgpt.com/codex/tasks/task_e_685fae6258f0832892ba092774333b9e